### PR TITLE
Edits to episodes 11 and 12

### DIFF
--- a/_episodes/11-assembly_challenge.md
+++ b/_episodes/11-assembly_challenge.md
@@ -53,6 +53,11 @@ stats.sh contigs.fa | grep 'Max contig length:' > max_contig.txt
 ~~~
 {: .language-bash}
 
+The following figure presents the steps involved in the above script, when run on the `ref` samples:
+
+![whole_new_workflow](https://user-images.githubusercontent.com/55948629/188318845-9c2b3e64-23d2-4449-8b03-6575f9930d87.png)
+
+
 > ## Challenge
 >
 > Run the script as-is. In order to make it work, you should make a new conda environment named "assembly-env" with

--- a/_episodes/12-cleaning_up.md
+++ b/_episodes/12-cleaning_up.md
@@ -158,7 +158,7 @@ Job counts:
 	10
 ~~~
 
-Snakemake wants to re-run all the *salmon_quant* jobs, which makes sense, but we know the results are good, and
+Snakemake wants to re-run all the *salmon_quant* jobs (and the *kallisto_quant* jobs, if you completed the exercise above), which makes sense. However, we know the results are good, and
 don't want to waste time re-making them, so we can fudge the timestamps using the `--touch` option. In the words
 of the Snakemake manual, "This is used to pretend that the rules were executed, in order to fool future
 invocations of snakemake."


### PR DESCRIPTION
Hi Tim,

I've added a figure for the episode where a whole new workflow is constructed. I think it's helpful for learners to see an example DAG for the new script. I/we have used this figure a couple of times now while teaching, so I thought it could go into the episode if you find it helpful.

I also added a small edit in episode 12: if learners perform the challenge where `kallisto_quant` is changed to take gzipped files, then snakemake will also want to re-run `kallisto_quant` after running `touch` on files in the `trimmed` folder.

Cheers,
Ezra